### PR TITLE
Fix compile warnings.

### DIFF
--- a/source/tcppLibrary.hpp
+++ b/source/tcppLibrary.hpp
@@ -643,11 +643,11 @@ namespace tcpp
 
 				uint8_t charsToRemove = 0;
 
-				do
+				while ((i < inputLine.length()) && std::isdigit(ch = inputLine[i++]))
 				{
 					number.push_back(ch);
 					++charsToRemove;
-				} while ((i < inputLine.length()) && std::isdigit(ch = inputLine[++i]));
+				}
 
 				inputLine.erase(0, charsToRemove);
 				mCurrPos += charsToRemove;

--- a/tests/coreTests.cpp
+++ b/tests/coreTests.cpp
@@ -312,6 +312,25 @@ TEST_CASE("Preprocessor Tests")
 		REQUIRE(output == inputSource);
 	}
 
+	SECTION("TestProcess_PassFloatingPointValue_ReturnsThisValue2")
+	{
+		std::string inputSource = "float c = nebula(layer2_coord * 3.0) * 0.35 - 0.05";
+		StringInputStream input(inputSource);
+		Lexer lexer(input);
+
+		bool result = true;
+
+		Preprocessor preprocessor(lexer, [&result](auto&& arg)
+		{
+			std::cerr << "Error: " << ErrorTypeToString(arg.mType) << std::endl;
+			result = false;
+		});
+
+		auto&& output = preprocessor.Process();
+		std::cout << output << std::endl;
+		REQUIRE(output == inputSource);
+	}
+
 	SECTION("TestProcess_PassTwoStringsWithConcatOperation_ReturnsSingleString")
 	{
 		std::string inputSource = "AAA   ## BB";


### PR DESCRIPTION
I have fixes for compilation warnings. Please take look.

The following warnings are generated when compiling for Android with clang:

`  /home/auygun/code/kaliber/src/engine/../third_party/tcpp/tcppLibrary.hpp:419:15: error: field 'mCurrLineIndex' will be initialized after field 'mDirectivesTable' [-Werror,-Wreorder]
          mCurrLine(), mCurrLineIndex(0), mDirectivesTable
                       ^
  /home/auygun/code/kaliber/src/engine/../third_party/tcpp/tcppLibrary.hpp:1419:20: error: lambda capture 'this' is not used [-Werror,-Wunused-lambda-capture]
                  auto evalCall = [this, &tokens]()
                                   ^~~~~
  /home/auygun/code/kaliber/src/engine/../third_party/tcpp/tcppLibrary.hpp:1419:27: error: lambda capture 'tokens' is not used [-Werror,-Wunused-lambda-capture]
                  auto evalCall = [this, &tokens]()
                                       ~~~^~~~~~
  /home/auygun/code/kaliber/src/engine/../third_party/tcpp/tcppLibrary.hpp:1428:12: error: 41 enumeration values not handled in switch: 'DEFINE', 'IF', 'ELSE'... [-Werror,-Wswitch]
                          switch (currToken.mType)
                                  ^
  /home/auygun/code/kaliber/src/engine/../third_party/tcpp/tcppLibrary.hpp:1459:12: error: 41 enumeration values not handled in switch: 'IDENTIFIER', 'DEFINE', 'IF'... [-Werror,-Wswitch]
                          switch (currToken.mType)
                                  ^
  /home/auygun/code/kaliber/src/engine/../third_party/tcpp/tcppLibrary.hpp:1454:21: error: lambda capture 'this' is not used [-Werror,-Wunused-lambda-capture]
                  auto evalUnary = [this, &tokens, &evalPrimary]()
                                    ^~~~~
  /home/auygun/code/kaliber/src/engine/../third_party/tcpp/tcppLibrary.hpp:1479:13: error: 41 enumeration values not handled in switch: 'IDENTIFIER', 'DEFINE', 'IF'... [-Werror,-Wswitch]
                                  switch (currToken.mType)
                                          ^
  /home/auygun/code/kaliber/src/engine/../third_party/tcpp/tcppLibrary.hpp:1472:30: error: lambda capture 'this' is not used [-Werror,-Wunused-lambda-capture]
                  auto evalMultiplication = [this, &tokens, &evalUnary]()
                                             ^~~~~
  /home/auygun/code/kaliber/src/engine/../third_party/tcpp/tcppLibrary.hpp:1500:13: error: 41 enumeration values not handled in switch: 'IDENTIFIER', 'DEFINE', 'IF'... [-Werror,-Wswitch]
                                  switch (currToken.mType)
                                          ^
  /home/auygun/code/kaliber/src/engine/../third_party/tcpp/tcppLibrary.hpp:1493:24: error: lambda capture 'this' is not used [-Werror,-Wunused-lambda-capture]
                  auto evalAddition = [this, &tokens, &evalMultiplication]()
                                       ^~~~~
  /home/auygun/code/kaliber/src/engine/../third_party/tcpp/tcppLibrary.hpp:1524:13: error: 39 enumeration values not handled in switch: 'IDENTIFIER', 'DEFINE', 'IF'... [-Werror,-Wswitch]
                                  switch (currToken.mType)
                                          ^
  /home/auygun/code/kaliber/src/engine/../third_party/tcpp/tcppLibrary.hpp:1514:26: error: lambda capture 'this' is not used [-Werror,-Wunused-lambda-capture]
                  auto evalComparison = [this, &tokens, &evalAddition]()
                                         ^~~~~
  /home/auygun/code/kaliber/src/engine/../third_party/tcpp/tcppLibrary.hpp:1551:13: error: 41 enumeration values not handled in switch: 'IDENTIFIER', 'DEFINE', 'IF'... [-Werror,-Wswitch]
                                  switch (currToken.mType)
                                          ^
  /home/auygun/code/kaliber/src/engine/../third_party/tcpp/tcppLibrary.hpp:1544:24: error: lambda capture 'this' is not used [-Werror,-Wunused-lambda-capture]
                  auto evalEquality = [this, &tokens, &evalComparison]()
                                       ^~~~~
  /home/auygun/code/kaliber/src/engine/../third_party/tcpp/tcppLibrary.hpp:1565:23: error: lambda capture 'this' is not used [-Werror,-Wunused-lambda-capture]
                  auto evalAndExpr = [this, &tokens, &evalEquality]()
                                      ^~~~~
  /home/auygun/code/kaliber/src/engine/../third_party/tcpp/tcppLibrary.hpp:1577:22: error: lambda capture 'this' is not used [-Werror,-Wunused-lambda-capture]
                  auto evalOrExpr = [this, &tokens, &evalAndExpr]()
                                     ^~~~~
  /home/auygun/code/kaliber/src/engine/../third_party/tcpp/tcppLibrary.hpp:1413:10: error: unused variable 'pos' [-Werror,-Wunused-variable]
                  size_t pos = 0;
                         ^
  /home/auygun/code/kaliber/src/engine/shader_source.cc:67:44: error: lambda capture 'result' is not used [-Werror,-Wunused-lambda-capture]
    tcpp::Preprocessor preprocessor(lexer, [&result](auto&& arg)
                                            ~^~~~~~
  18 errors generated.
`