### PR TITLE
Fix newline right after spaces after define

### DIFF
--- a/source/tcppLibrary.hpp
+++ b/source/tcppLibrary.hpp
@@ -1103,11 +1103,14 @@ namespace tcpp
 
 			while ((currToken = mpLexer->GetNextToken()).mType == E_TOKEN_TYPE::SPACE); // \note skip space tokens
 
-			desc.mValue.push_back(currToken);
-
-			while ((currToken = lexer.GetNextToken()).mType != E_TOKEN_TYPE::NEWLINE)
+			if (currToken.mType != E_TOKEN_TYPE::NEWLINE)
 			{
 				desc.mValue.push_back(currToken);
+
+				while ((currToken = lexer.GetNextToken()).mType != E_TOKEN_TYPE::NEWLINE)
+				{
+					desc.mValue.push_back(currToken);
+				}
 			}
 
 			if (desc.mValue.empty())


### PR DESCRIPTION
You can reproduce the bug with such text to preprocess:
```
#define XXX 
#pragma something
```
Which is actually `#define XXX \n #pragma something` 

Bug Explanation:

Notice there is an space after XXX and that makes the code path go into extracting the define value.

Then it skips all the space tokens.

But there is a bug here if there is a NEW_LINE right after the spaces and that makes it push the NEW_LINE token into define values and then move onto adding everything in the next line to the define values until it reaches yet ANOTHER new line.

Fix Explanation:

After skipping the spaces, If the current token is NEW_LINE then don't push back to the define values until it reaches a new line.

