### PR TITLE
Fix #undef handling

### DIFF
--- a/source/tcppLibrary.hpp
+++ b/source/tcppLibrary.hpp
@@ -981,7 +981,11 @@ namespace tcpp
 					break;
 				case E_TOKEN_TYPE::UNDEF:
 					currToken = mpLexer->GetNextToken();
+					_expect(E_TOKEN_TYPE::SPACE, currToken.mType);
+
+					currToken = mpLexer->GetNextToken();
 					_expect(E_TOKEN_TYPE::IDENTIFIER, currToken.mType);
+
 					_removeMacroDefinition(currToken.mRawView);
 					break;
 				case E_TOKEN_TYPE::IF:


### PR DESCRIPTION
The #undef directive has a space after it, like #ifdef, which is being handled incorrectly in the current code.