### PR TITLE
Fixes to #elif and _evaluateExpression

### DIFF
--- a/source/tcppLibrary.hpp
+++ b/source/tcppLibrary.hpp
@@ -1553,7 +1553,7 @@ namespace tcpp
 
 			// even number of NOTs: false ^ false = false, false ^ true = true
 			// odd number of NOTs: true ^ false = true (!false), true ^ true = false (!true)
-			return resultApply ^ evalPrimary();
+			return static_cast<int>(resultApply) ^ evalPrimary();
 		};
 
 		auto evalMultiplication = [&tokens, &evalUnary]()

--- a/source/tcppLibrary.hpp
+++ b/source/tcppLibrary.hpp
@@ -1103,11 +1103,14 @@ namespace tcpp
 
 			while ((currToken = mpLexer->GetNextToken()).mType == E_TOKEN_TYPE::SPACE); // \note skip space tokens
 
-			desc.mValue.push_back(currToken);
-
-			while ((currToken = lexer.GetNextToken()).mType != E_TOKEN_TYPE::NEWLINE)
+			if (currToken.mType != E_TOKEN_TYPE::NEWLINE)
 			{
 				desc.mValue.push_back(currToken);
+
+				while ((currToken = lexer.GetNextToken()).mType != E_TOKEN_TYPE::NEWLINE)
+				{
+					desc.mValue.push_back(currToken);
+				}
 			}
 
 			if (desc.mValue.empty())


### PR DESCRIPTION
# Fix to elif

Currently, #elif will visit every block, performing their defines, based only on the condition on the elif itself. I've added a mHasIfBlockBeenEntered boolean to TIfStackEntry that is set to true if one of the blocks hasn't been skipped, and elif and else will automatically skip if it is true.

# Fixes to _evaluateExpression

## Advancing the tokens on the callbacks

Currently, tokens.front() is called to search for special characters, but it is not consumed. I've added tokens.erase(tokens.cbegin()); so that the symbol is consumed and then the rest of the expression can be parsed.

## Handling of NOT

I've changed the handling of the unary not operator allowing it to be used before the rest of the expression.

## Handling of defined(X)

Currently, there is a check for defined(X) that will go into an empty lambda. I've implemented a check for a "defined" identifier which will then parse a defined(X) pattern for the identifier X.